### PR TITLE
Correction URL in Visualisierung

### DIFF
--- a/skript/lorenz/references.bib
+++ b/skript/lorenz/references.bib
@@ -73,6 +73,6 @@ author = "Euler, Leonhard",
 @online{visualisierung,
 	title = {Online-Visualisierung Lorenz-Attraktor},
 	date = {29.7.18},
-	url = {lorenz.olidias.ch}
+	url = {https://lorenz.olidias.ch}
 	
 }


### PR DESCRIPTION
Einzige URL in 'Bibliography'-Verzeichnis ohne Protokoll. Darum habe ich es im Stil den anderen URL's angepasst.